### PR TITLE
Add automated linting and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.pytest_cache/
+/.tox/
 /build/
 /dist/
 /emanate.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ build:
 clean:
 	rm -rf build release dist emanate.egg-info
 
-.PHONY: release build clean
+test:
+	tox
+
+.PHONY: release build clean test

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -92,7 +92,7 @@ class Emanate:
 def parse_args(args=None):
     argparser = ArgumentParser(
         description="symlink files from one directory to another",
-        argument_default=SUPPRESS
+        argument_default=SUPPRESS,
     )
     argparser.add_argument("--clean", help="Remove symlinks.")
     argparser.add_argument("--destination",
@@ -132,7 +132,7 @@ def main(args=None):
 
     return Emanate(
         config.from_json(args.config) if args.config.exists() else None,
-        config.resolve(vars(args))
+        config.resolve(vars(args)),
     ).run()
 
 

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -116,10 +116,13 @@ def parse_args(args=None):
 
 
 def main(args=None):
-    """Emanate prioritizes configuration sources in the following order:
+    """Invoke Emanate from command-line arguments.
+
+    Emanate prioritizes configuration sources in the following order:
     - default values have lowest priority;
     - the configuration file overrides defaults;
-    - command-line arguments override everything."""
+    - command-line arguments override everything.
+    """
     args = parse_args(args)
     if args.config is None:
         if 'source' in args:

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -115,12 +115,12 @@ def parse_args(args=None):
     return argparser.parse_args(args)
 
 
-def main():
+def main(args=None):
     """Emanate prioritizes configuration sources in the following order:
     - default values have lowest priority;
     - the configuration file overrides defaults;
     - command-line arguments override everything."""
-    args = parse_args()
+    args = parse_args(args)
     if args.config is None:
         if 'source' in args:
             args.config = args.source / "emanate.json"

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -38,7 +38,7 @@ class Emanate:
             return True
 
         result = None
-        while not result in ["y", "n", "\n"]:
+        while result not in ["y", "n", "\n"]:
             print("{} [Y/n] ".format(prompt), end="", flush=True)
             result = sys.stdin.read(1).lower()
 
@@ -130,6 +130,7 @@ def main():
         config.from_json(args.config) if args.config.exists() else None,
         config.resolve(vars(args))
     ).run()
+
 
 if __name__ == '__main__':
     exit(main())

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -9,6 +9,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 import sys
 
+
 class Emanate:
     def __init__(self, *configs):
         self.config   = config.merge(config.DEFAULTS, *configs)

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -3,11 +3,11 @@
 # Example usage:
 # TODO
 
-from . import config
 from argparse import ArgumentParser, SUPPRESS
 from fnmatch import fnmatch
 from pathlib import Path
 import sys
+from . import config
 
 
 class Emanate:
@@ -42,9 +42,10 @@ class Emanate:
             print("{} [Y/n] ".format(prompt), end="", flush=True)
             result = sys.stdin.read(1).lower()
 
-        return (result != "n")
+        return result != "n"
 
-    def backup(self, dest_file):
+    @staticmethod
+    def backup(dest_file):
         # Rename the file so we can safely write to the original path.
         new_name = str(dest_file) + ".emanate"
         dest_file.rename(new_name)
@@ -63,7 +64,7 @@ class Emanate:
             # If the user said no, skip the file.
             if not self.confirm_replace(dest_file):
                 return False
-            self.backup(dest_file)
+            Emanate.backup(dest_file)
 
         print("{!r} -> {!r}".format(str(src_file), str(dest_file)))
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -105,12 +105,14 @@ def resolve(config, cwd=None):
     result = config.copy()
 
     for key in CONFIG_PATHS:
-        if key in result:
-            if isinstance(result[key], str):
-                result[key] = Path(result[key])
+        if key not in result:
+            continue
 
-            if not result[key].is_absolute():
-                result[key] = cwd / result[key].expanduser()
+        if isinstance(result[key], str):
+            result[key] = Path(result[key])
+
+        if not result[key].is_absolute():
+            result[key] = cwd / result[key].expanduser()
 
     return result
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -1,4 +1,3 @@
-import collections.abc
 import json
 from pathlib import Path
 
@@ -25,6 +24,7 @@ DEFAULTS = {
     'source': Path.cwd(),
 }
 
+
 class AttrDict(dict):
     def __getattr__(self, name):
         if name not in self:
@@ -32,6 +32,7 @@ class AttrDict(dict):
                                  format(type(self).__name__, name))
 
         return self[name]
+
 
 def merge(*configs, strict_resolve=True):
     """Merges a sequence of configuration dict-like objects.
@@ -55,6 +56,7 @@ def merge(*configs, strict_resolve=True):
 
 CONFIG_PATHS = ('destination', 'source')
 
+
 def is_resolved(config):
     for key in CONFIG_PATHS:
         if key in config:
@@ -63,6 +65,7 @@ def is_resolved(config):
                 return False
 
     return True
+
 
 def resolve(config, cwd=Path.cwd()):
     """Returns a new config dict-like, similar to its input,
@@ -80,6 +83,7 @@ def resolve(config, cwd=Path.cwd()):
                 result[key] = cwd / result[key].expanduser()
 
     return result
+
 
 def from_json(path):
     """Takes a pathlib.Path object designating a JSON configuration for Emanate,

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -90,13 +90,16 @@ def is_resolved(config):
     return True
 
 
-def resolve(config, cwd=Path.cwd()):
+def resolve(config, cwd=None):
     """Convert path options to pathlib.Path objects, and resolve relative paths.
 
     Returns a new config dict-like, similar to its input, with all paths
     attributes converted to pathlib objects, and relative paths resolved
     relatively to `cwd`.
     """
+    if cwd is None:
+        cwd = Path.cwd()
+
     assert isinstance(cwd, Path)
     assert cwd.is_absolute()
     result = config.copy()

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -1,3 +1,9 @@
+"""Emanate's configuration module
+
+emanate.config defines Emanate's defaults, along with helpers for working with
+config objects, loading them from JSON files, and dealing with relative paths.
+"""
+
 import json
 from pathlib import Path
 
@@ -26,6 +32,8 @@ DEFAULTS = {
 
 
 class AttrDict(dict):
+    """AttrDict is a simple wrapper around the standard dict, which
+    allows accessing values with obj.foo rather than obj['foo']."""
     def __getattr__(self, name):
         if name not in self:
             raise AttributeError("{!r} object has no attribute {!r}".
@@ -58,6 +66,8 @@ CONFIG_PATHS = ('destination', 'source')
 
 
 def is_resolved(config):
+    """Checks whether all path options in a config object
+    are pathlib objects designating an absolute path."""
     for key in CONFIG_PATHS:
         if key in config:
             value = config[key]

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -1,4 +1,4 @@
-"""Emanate's configuration module
+"""Emanate's configuration module.
 
 emanate.config defines Emanate's defaults, along with helpers for working with
 config objects, loading them from JSON files, and dealing with relative paths.
@@ -33,8 +33,8 @@ DEFAULTS = {
 
 
 class AttrDict(dict):
-    """AttrDict is a simple wrapper around the standard dict, which
-    allows accessing values with obj.foo rather than obj['foo']."""
+    """Simple wrapper around dict, allowing accessing values as attributes."""
+
     def __getattr__(self, name):
         if name not in self:
             raise AttributeError("{!r} object has no attribute {!r}".
@@ -65,10 +65,11 @@ def _merge_one(config, dict_like):
 
 
 def merge(*configs, strict_resolve=True):
-    """Merges a sequence of configuration dict-like objects.
-    Later configs overide previous ones, and the `ignore` attributes are
-    merged (according to set union)."""
+    """Merge a sequence of configuration dict-like objects.
 
+    Later configs overide previous ones, and the `ignore` attributes are
+    merged (according to set union).
+    """
     if strict_resolve:
         assert all(map(is_resolved, configs))
 
@@ -79,8 +80,7 @@ CONFIG_PATHS = ('destination', 'source')
 
 
 def is_resolved(config):
-    """Checks whether all path options in a config object
-    are pathlib objects designating an absolute path."""
+    """Check that all path options in a config object are absolute Paths."""
     for key in CONFIG_PATHS:
         if key in config:
             value = config[key]
@@ -91,8 +91,12 @@ def is_resolved(config):
 
 
 def resolve(config, cwd=Path.cwd()):
-    """Returns a new config dict-like, similar to its input,
-    with all relative paths resolved relatively to `cwd`."""
+    """Convert path options to pathlib.Path objects, and resolve relative paths.
+
+    Returns a new config dict-like, similar to its input, with all paths
+    attributes converted to pathlib objects, and relative paths resolved
+    relatively to `cwd`.
+    """
     assert isinstance(cwd, Path)
     assert cwd.is_absolute()
     result = config.copy()
@@ -109,7 +113,10 @@ def resolve(config, cwd=Path.cwd()):
 
 
 def from_json(path):
-    """Takes a pathlib.Path object designating a JSON configuration for Emanate,
-    loads it, and resolve paths relative to the configuration file."""
+    """Load an Emanate configuration from a file.
+
+    Takes a pathlib.Path object designating a JSON configuration file,
+    loads it, and resolve paths relative to the filepath.
+    """
     assert isinstance(path, Path)
     return resolve(json.load(path.open()), cwd=path.parent)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 setup(
     name='emanate',
     version='2.0.0',
-    description='Symlink files from one directory to another, similarly to Effuse and Stow.',
+    description='Symlink files from one directory to another, '
+                'similarly to Effuse and Stow.',
     author='Ellen Marie Dash',
     author_email='me@duckie.co',
     url='https://github.com/duckinator/emanate',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from emanate import main
+
+
+def test_config_relative_path():
+    """Test paths relative to the configuration file.
+
+    Creates the following hierarchy, and calls `emanate --source tmpdir/src`:
+    tmpdir
+    ├── dest
+    └── src
+        ├── foo
+        └── emanate.json
+
+    This test then asserts that tmpdir/dest/foo exists, and that
+    tmpdir/dest/emanate.json does not.
+    """
+    with TemporaryDirectory() as tmpdir:
+        # Setup the test environment
+        tmpdir = Path(tmpdir)
+        src = tmpdir.joinpath('src')
+        dest = tmpdir.joinpath('dest')
+        src.mkdir()
+        src.joinpath('foo').touch()
+        dest.mkdir()
+
+        with src.joinpath('emanate.json').open(mode='w') as config:
+            json.dump({
+                'destination': '../dest'
+            }, config)
+
+        assert not dest.joinpath('foo').exists()
+        main(['--source', str(src)])
+        assert dest.joinpath('foo').samefile(src.joinpath('foo'))
+        assert not dest.joinpath('emanate.json').exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,7 +28,7 @@ def test_config_relative_path():
 
         with src.joinpath('emanate.json').open(mode='w') as config:
             json.dump({
-                'destination': '../dest'
+                'destination': '../dest',
             }, config)
 
         assert not dest.joinpath('foo').exists()

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,8 @@ commands = flake8 --ignore=E221 --max-complexity 5
 
 [testenv:pylint]
 deps = pylint
-commands = pylint emanate -d bad-whitespace
+commands = pylint emanate -d bad-whitespace,missing-docstring
+
+[testenv:docstyle]
+deps = pydocstyle
+commands = pydocstyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
 [testenv:py3]
 deps = pytest
 commands = pytest
+
+[testenv:flake8]
+deps = flake8
+commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@ commands = pytest
 
 [testenv:flake8]
 deps = flake8
-commands = flake8
+commands = flake8 --ignore=E221

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,7 @@ commands = pytest
 [testenv:flake8]
 deps = flake8
 commands = flake8 --ignore=E221
+
+[testenv:pylint]
+deps = pylint
+commands = pylint emanate -d bad-whitespace

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[testenv:py3]
+deps = pytest
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ commands = pytest
 [testenv:flake8]
 deps = flake8
        flake8-bugbear
+       flake8-commas
 commands = flake8
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = flake8
 [flake8]
 select = C,E,F,W,B,B9
 ignore = E221
-max-complexity = 5
+max-complexity = 7
 
 
 [testenv:pylint]

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,11 @@ commands = pytest
 
 [testenv:flake8]
 deps = flake8
+       flake8-bugbear
 commands = flake8
 
 [flake8]
+select = C,E,F,W,B,B9
 ignore = E221
 max-complexity = 5
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ commands = pytest
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --ignore=E221
+commands = flake8 --ignore=E221 --max-complexity 5
 
 [testenv:pylint]
 deps = pylint

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,20 @@
 deps = pytest
 commands = pytest
 
+
 [testenv:flake8]
 deps = flake8
-commands = flake8 --ignore=E221 --max-complexity 5
+commands = flake8
+
+[flake8]
+ignore = E221
+max-complexity = 5
+
 
 [testenv:pylint]
 deps = pylint
 commands = pylint emanate -d bad-whitespace,missing-docstring
+
 
 [testenv:docstyle]
 deps = pydocstyle


### PR DESCRIPTION
- [x] Run ~PEP8 checking and~ `pylint`
- [x] Run `pytest`
- [x] Actually write some ~unit~ tests for `pytest`
- [x] Run `flake8` (which includes PEP8 checking)
  - Check syntax & style (default behaviour of `flake8`)
  - Check for trailing commas
  - Check cyclomatic complexity (the number of different paths through a function)
  - Check docstring style
  - Enable the `flake8-bugbear` plugin to get extra lint (and it found a legit bug!)