### PR TITLE
Fix directory creation

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -26,7 +26,8 @@ class Emanate:
             return False
 
         if path_obj.is_dir():
-            Path(self.dest, path_obj).mkdir(exist_ok=True)
+            dir = self.dest / path_obj.relative_to(self.config.source)
+            dir.mkdir(exist_ok=True)
             return False
 
         return True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,6 +109,9 @@ def test_no_config():
             options=lambda tmpdir: ['--dest', tmpdir / 'dest'],
     ):
         assert (tmpdir / 'dest' / 'foo').samefile(tmpdir / 'src'  / 'foo')
+        assert (tmpdir / 'dest' / 'bar' / 'baz').samefile(
+            tmpdir / 'src'  / 'bar' / 'baz'
+        )
 
 
 def test_empty_config():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,6 +102,7 @@ def test_no_config():
             tree={
                 'src': {
                     'foo': '',
+                    'bar': {'baz': ''},
                 },
                 'dest': {},
             },


### PR DESCRIPTION
I just noticed earlier changes (#5 ?) broke the directory creation in `Emanate.valid_file`.  This is a test and bugfix.

BTW, I really think this should go in a separate method from `valid_file`, but we can do that when we refactor away `config.clean`.