### PR TITLE
tests: Protect the user's home directory

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,7 @@
 import json
-import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from contextlib import contextmanager
 import emanate
+from pathlib import Path
+from utils import cd, directory_tree
 
 
 def main(*pargs):
@@ -12,47 +10,6 @@ def main(*pargs):
     print('cwd:', Path.cwd())
     print('emanate', *args)
     emanate.main(args)
-
-
-@contextmanager
-def cd(path):
-    """Context manager for temporarily changing directory."""
-    if isinstance(path, Path):
-        path = str(path)
-
-    cwd = Path.cwd()
-    try:
-        os.chdir(path)
-        yield
-    finally:
-        os.chdir(str(cwd))
-
-
-@contextmanager
-def directory_tree(obj):
-    """Provide a temporary directory populated with configurable contents."""
-    def mktree(path, obj):
-        """Populate a directory from a dict-like describing its contents."""
-        assert isinstance(path, Path)
-        # File by content
-        if isinstance(obj, str):
-            with path.open(mode='w') as file:
-                file.write(obj)
-
-        # Directory
-        elif 'type' not in obj:
-            path.mkdir(exist_ok=True)
-            for name, child in obj.items():
-                mktree(path / name, child)
-
-        elif obj['type'] == 'link':
-            path.symlink_to(obj['target'])
-
-    with TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
-        if obj:
-            mktree(tmpdir, obj)
-        yield tmpdir
 
 
 def helper(tree=None, source='src', options=lambda _: []):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,3 +45,19 @@ def directory_tree(obj):
         if obj:
             mktree(tmpdir, obj)
         yield tmpdir
+
+
+@contextmanager
+def home(path):
+    """Temporarily set the HOME environment variable."""
+    home = os.getenv('HOME', None)
+
+    try:
+        os.environ['HOME'] = str(path)
+        yield
+
+    finally:
+        if home is not None:
+            os.environ['HOME'] = home
+        else:
+            del os.environ['HOME']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,47 @@
+"""Utility context managers for Emanate's testsuite."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
+
+
+@contextmanager
+def cd(path):
+    """Context manager for temporarily changing directory."""
+    if isinstance(path, Path):
+        path = str(path)
+
+    cwd = Path.cwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(str(cwd))
+
+
+@contextmanager
+def directory_tree(obj):
+    """Provide a temporary directory populated with configurable contents."""
+    def mktree(path, obj):
+        """Populate a directory from a dict-like describing its contents."""
+        assert isinstance(path, Path)
+        # File by content
+        if isinstance(obj, str):
+            with path.open(mode='w') as file:
+                file.write(obj)
+
+        # Directory
+        elif 'type' not in obj:
+            path.mkdir(exist_ok=True)
+            for name, child in obj.items():
+                mktree(path / name, child)
+
+        elif obj['type'] == 'link':
+            path.symlink_to(obj['target'])
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        if obj:
+            mktree(tmpdir, obj)
+        yield tmpdir


### PR DESCRIPTION
I noticed I had some symlink in my homedir made by (broken) runs of the emanate testsuite, so I just added something to make sure we don't write to the user's homedir.

This builds off #14, but you can merge in whichever order you like.