### PR TITLE
test_config: Use Path.samefile() rather than == in test_defaults

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,9 @@ def test_defaults():
 
     with directory_tree({}) as tmpdir:
         with cd(tmpdir):
-            assert config.defaults().source == Path.cwd() == tmpdir
+            assert config.defaults().source.samefile(tmpdir)
+            assert Path.cwd().samefile(tmpdir)
 
         with home(tmpdir):
-            assert config.defaults().destination == Path.home() == tmpdir
+            assert config.defaults().destination.samefile(tmpdir)
+            assert Path.home().samefile(tmpdir)


### PR DESCRIPTION
This deals correctly with the same location having several paths, due to symlinks and the like.

Hopefully this is the reason for the test failures on Travis' macOS environment?