### PR TITLE
Fix the --clean option

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -148,7 +148,9 @@ def _parse_args(args=None):
         description="Link files from one directory to another",
         argument_default=SUPPRESS,
     )
-    argparser.add_argument("--clean", help="Remove symbolic links.")
+    argparser.add_argument("--clean",
+                           action="store_true",
+                           help="Remove symbolic links.")
     argparser.add_argument("--destination",
                            metavar="DESTINATION",
                            help="Directory containing the symbolic links.")

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -122,9 +122,11 @@ class Emanate:
 
     @staticmethod
     def _del_symlink(src, dest):
-        print("{!r}".format(str(dest)))
+        if not dest.exists():
+            return True
 
-        if dest.exists() and src.samefile(dest):
+        print("{!r}".format(str(dest)))
+        if dest.samefile(src):
             dest.unlink()
 
         return not dest.exists()

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -103,44 +103,39 @@ class Emanate:
         new_name = str(dest_file) + ".emanate"
         dest_file.rename(new_name)
 
-    def _add_symlink(self, path_obj):
-        src_file  = path_obj.resolve()
-        dest_file = self.dest / path_obj.relative_to(self.config.source)
-
+    def _add_symlink(self, src, dest):
         # If the symbolic link is already in place, skip it.
-        if dest_file.exists() and src_file.samefile(dest_file):
+        if dest.exists() and src.samefile(dest):
             return True
 
         # If the file exists and _isn't_ the symbolic link we're
         # trying to make, prompt the user to determine what to do.
-        if dest_file.exists():
+        if dest.exists():
             # If the user said no, skip the file.
-            if not self.confirm_replace(dest_file):
+            if not self.confirm_replace(dest):
                 return False
-            Emanate.backup(dest_file)
+            Emanate.backup(dest)
 
-        print("{!r} -> {!r}".format(str(src_file), str(dest_file)))
+        print("{!r} -> {!r}".format(str(src), str(dest)))
+        dest.symlink_to(src)
+        return src.samefile(dest)
 
-        dest_file.symlink_to(src_file)
+    @staticmethod
+    def _del_symlink(src, dest):
+        print("{!r}".format(str(dest)))
 
-        return src_file.samefile(dest_file)
+        if dest.exists() and src.samefile(dest):
+            dest.unlink()
 
-    def _del_symlink(self, path_obj):
-        src_file  = path_obj.resolve()
-        dest_file = self.dest / path_obj.relative_to(self.config.source)
-
-        print("{!r}".format(str(dest_file)))
-
-        if dest_file.exists() and src_file.samefile(dest_file):
-            dest_file.unlink()
-
-        return not dest_file.exists()
+        return not dest.exists()
 
     def run(self):
         """Execute Emanate as configured."""
         all_files = Path(self.config.source).glob("**/*")
         for file in filter(self.valid_file, all_files):
-            self.function(file)
+            src  = file.resolve()
+            dest = self.dest / file.relative_to(self.config.source)
+            self.function(src, dest)
 
 
 def _parse_args(args=None):

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -127,7 +127,7 @@ class Emanate:
 
     def _del_symlink(self, path_obj):
         src_file  = path_obj.resolve()
-        dest_file = Path(self.dest, path_obj)
+        dest_file = self.dest / path_obj.relative_to(self.config.source)
 
         print("{!r}".format(str(dest_file)))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,3 +92,24 @@ def test_empty_config():
     ):
         assert (tmpdir / 'dest' / 'foo').samefile(tmpdir / 'src'  / 'foo')
         assert not (tmpdir / 'dest'  / 'emanate.json').exists()
+
+
+def test_clean():
+    """Test cleaning an existing destination directory."""
+    for tmpdir in helper(
+            tree={
+                'src': {
+                    'bar': '',
+                    'foo': '',
+                    'emanate.json': json.dumps({'destination': '../dest'}),
+                },
+                'dest': {
+                    'foo': {'type': 'link', 'target': '../src/foo'},
+                },
+            },
+            options=lambda _: ['--clean']):
+        for f in ['bar', 'foo']:
+            assert not (tmpdir / 'dest' / f).exists()
+            assert (tmpdir / 'src' / f).exists()
+
+        assert (tmpdir / 'src' / 'emanate.json').exists()


### PR DESCRIPTION
- [x] Add a test for `--clean`
- [x] Fix the CLI parsing for that option (bug found by `test_clean`)
- [x] Fix the actual `--clean` behaviour (it removed from the source directory; found by `test_clean`)

Bug initially mentioned by @duckinator 