### PR TITLE
Travis: Cache various artefacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
     - $HOME/Library/Caches/Homebrew
     - $HOME/.pyenv/cache
     - $HOME/.pyenv/versions
+    - $HOME/.pyenv/shims
 
 install: pip install tox
 script:  tox
@@ -61,15 +62,17 @@ matrix:
 
 before_install:
   - |
-    if [ "$TRAVIS_OS_NAME" == "osx" ] && [ ! -d "$HOME/.pyenv/versions/$PYENV_VERSION" ]; then
-      # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
-      brew update
-      # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
-      brew upgrade openssl readline pyenv
-      # Remove everything unneeded from the brew cache
-      brew cleanup -s
-      # Install the desired python version
-      pyenv install $PYENV_VERSION
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      if [ ! -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || [ ! -d "$HOME/.pyenv/shims" ]; then
+        # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
+        brew update
+        # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
+        brew upgrade openssl readline pyenv
+        # Remove everything unneeded from the brew cache
+        brew cleanup -s
+        # Install the desired python version
+        pyenv install $PYENV_VERSION
+      fi
     fi
   - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv global $PYENV_VERSION'
   - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv rehash'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ cache:
     - $HOME/Library/Caches/Homebrew
     - $HOME/.pyenv/cache
     - $HOME/.pyenv/versions
-    - $HOME/.pyenv/shims
 
 install: pip install tox
 script:  tox
@@ -61,20 +60,18 @@ matrix:
 
 
 before_install:
-  - |
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      if [ ! -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || [ ! -d "$HOME/.pyenv/shims" ]; then
-        # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
-        brew update
-        # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
-        brew upgrade openssl readline pyenv
-        # Remove everything unneeded from the brew cache
-        brew cleanup -s
-        # Install the desired python version
-        pyenv install $PYENV_VERSION
-      fi
-    fi
+  # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || [ -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || brew update'
+  # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || [ -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || brew upgrade openssl readline pyenv'
+  # Remove everything unneeded from the brew cache.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || [ -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || brew cleanup -s'
+  # Install the desired python version, if needed.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || [ -d "$HOME/.pyenv/versions/$PYENV_VERSION" ] || pyenv install $PYENV_VERSION'
+
+  # Switch to the desired python version.
   - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv global $PYENV_VERSION'
+  # Generate appropriate shims.
   - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv rehash'
 
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_install:
       pyenv install $PYENV_VERSION
     fi
   - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv global $PYENV_VERSION'
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv rehash'
 
   - python --version
   - pip    --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - $HOME/Library/Caches/Homebrew
     - $HOME/.pyenv_cache
 
-install: pip install tox-travis
+install: pip install tox
 script:  tox
 env:
   - TOXENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,15 +59,14 @@ matrix:
 
 
 before_install:
-  - |
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      brew update
-      # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
-      brew upgrade openssl readline pyenv
-      brew cleanup -s
-      # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
-      pyenv install $PYENV_VERSION
-    fi
+  # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew update'
+  # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew upgrade openssl readline pyenv'
+  # Remove everything unneeded from the brew cache
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew cleanup -s'
+  # Install the desired python version
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv install $PYENV_VERSION'
 
   - python --version
   - pip    --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ python:
   - "3.5"
   - "3.6"
 
+cache:
+  directories:
+    # Caching .tox can spell trouble for checkers which save state. Technically,
+    # pylint saves the previous build's score, but we don't use that value.
+    - .tox
+    - $HOME/.cache/pip
+
 install: pip install tox-travis
 script:  tox
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ cache:
 
     # Cache the Homebrew downloads and the built Python versions
     - $HOME/Library/Caches/Homebrew
-    - $HOME/.pyenv_cache
+    - $HOME/.pyenv/cache
+    - $HOME/.pyenv/versions
 
 install: pip install tox
 script:  tox
@@ -59,14 +60,18 @@ matrix:
 
 
 before_install:
-  # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
-  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew update'
-  # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
-  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew upgrade openssl readline pyenv'
-  # Remove everything unneeded from the brew cache
-  - '[ "$TRAVIS_OS_NAME" != "osx" ] || brew cleanup -s'
-  # Install the desired python version
-  - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv install $PYENV_VERSION'
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ] && [ ! -d "$HOME/.pyenv/versions/$PYENV_VERSION" ]; then
+      # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
+      brew update
+      # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
+      brew upgrade openssl readline pyenv
+      # Remove everything unneeded from the brew cache
+      brew cleanup -s
+      # Install the desired python version
+      pyenv install $PYENV_VERSION
+    fi
+  - '[ "$TRAVIS_OS_NAME" != "osx" ] || pyenv global $PYENV_VERSION'
 
   - python --version
   - pip    --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ cache:
     - .tox
     - $HOME/.cache/pip
 
+    # Cache the Homebrew downloads and the built Python versions
+    - $HOME/Library/Caches/Homebrew
+    - $HOME/.pyenv_cache
+
 install: pip install tox-travis
 script:  tox
 env:
@@ -60,6 +64,7 @@ before_install:
       brew update
       # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
       brew upgrade openssl readline pyenv
+      brew cleanup -s
       # See https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages.
       pyenv install $PYENV_VERSION
     fi


### PR DESCRIPTION
This was requested in #17, but I am not entirely sure how much of a speedup we will get:
- the latest CI build for #17 took 10 minutes (which is seemingly-high);
- the longest-running jobs are the OSX ones, which took almost 5 minutes; there, 4'30" (out of 5') are spent installing the desired Python version;
- the non-OSX jobs take less than 2 minutes, with only ~10s spent running our code.