### PR TITLE
Refactor API and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 /emanate.egg-info/
 __pycache__
+/venv

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -10,29 +10,8 @@ directory structure (and creating directories as needed).
 
 In `clean` mode, emanate instead removes such symbolic links.
 
-Examples:
-    Emanate defaults to using the current directory as source,
-    and the current user's home directory as destination::
-
-        ~/.dotfiles $ emanate
-
-    would create symbolic links in ~ for files in ~/.dotfiles
-
-    Emanate also defaults to looking for a configuration file in the source
-    directory, allowing usages such as::
-
-        $ cat software/foo/emanate.json
-        { 'destination': '/usr/local' }
-
-        $ emanate --source software/foo
-        ${PWD}/software/foo/bin/foo -> /usr/local/bin/foo
-        ${PWD}/software/foo/lib/library.so -> /usr/local/lib/library.so
-
-    See `emanate --help` for all command-line options.
-
 """
 
-from argparse import ArgumentParser, SUPPRESS
 from fnmatch import fnmatch
 from pathlib import Path
 import sys
@@ -138,56 +117,3 @@ class Emanate:
             src  = file.resolve()
             dest = self.dest / file.relative_to(self.config.source)
             self.function(src, dest)
-
-
-def _parse_args(args=None):
-    argparser = ArgumentParser(
-        description="Link files from one directory to another",
-        argument_default=SUPPRESS,
-    )
-    argparser.add_argument("--clean",
-                           action="store_true",
-                           help="Remove symbolic links.")
-    argparser.add_argument("--destination",
-                           metavar="DESTINATION",
-                           help="Directory containing the symbolic links.")
-    argparser.add_argument("--source",
-                           metavar="SOURCE",
-                           type=Path,
-                           help="Directory holding the files to symlink.")
-    argparser.add_argument("--no-confirm",
-                           action="store_false",
-                           dest="confirm",
-                           help="Don't prompt before replacing a file.")
-    argparser.add_argument("--config",
-                           metavar="CONFIG_FILE",
-                           default=None,
-                           type=Path,
-                           help="Configuration file to use.")
-
-    return argparser.parse_args(args)
-
-
-def main(args=None):
-    """Invoke Emanate from command-line arguments.
-
-    Emanate prioritizes configuration sources in the following order:
-    - default values have lowest priority;
-    - the configuration file overrides defaults;
-    - command-line arguments override everything.
-    """
-    args = _parse_args(args)
-    if args.config is None:
-        if 'source' in args:
-            args.config = args.source / "emanate.json"
-        else:
-            args.config = Path.cwd() / "emanate.json"
-
-    return Emanate(
-        config.from_json(args.config) if args.config.exists() else None,
-        config.resolve(vars(args)),
-    ).run()
-
-
-if __name__ == '__main__':
-    exit(main())

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -105,6 +105,23 @@ class Emanate:
 
         return not dest.exists()
 
+    class Execution(list):
+        """Describe an Emanate execution.
+
+        Callable once, useful to provide “dry-run”
+        functionality or report changes back to the user.
+        """
+
+        def __init__(self, func, iterable):
+            """Prepare an Emanate execution."""
+            self.func = func
+            super().__init__(iterable)
+
+        def run(self):
+            """Run a prepared execution."""
+            for args in self:
+                self.func(*args)
+
     def _files(self):
         all_files = Path(self.config.source).glob("**/*")
         for file in filter(self.valid_file, all_files):
@@ -114,10 +131,8 @@ class Emanate:
 
     def create(self):
         """Create symbolic links."""
-        for src, dest in self._files():
-            self._add_symlink(src, dest)
+        return Emanate.Execution(self._add_symlink, self._files())
 
     def clean(self):
         """Remove symbolic links."""
-        for src, dest in self._files():
-            self._del_symlink(src, dest)
+        return Emanate.Execution(self._del_symlink, self._files())

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -12,10 +12,14 @@ In `clean` mode, emanate instead removes such symbolic links.
 
 """
 
+from collections import namedtuple
 from fnmatch import fnmatch
 from pathlib import Path
 import sys
 from . import config
+
+
+FilePair = namedtuple('FilePair', ['src', 'dest'])
 
 
 class Emanate:
@@ -120,12 +124,12 @@ class Emanate:
         for file in filter(self.valid_file, all_files):
             src  = file.resolve()
             dest = self.dest / file.relative_to(self.config.source)
-            yield src, dest
+            yield FilePair(src, dest)
 
     def create(self):
         """Create symbolic links."""
         # Ignore files that are already linked.
-        gen = filter(lambda p: not (p[1].exists() and p[0].samefile(p[1])),
+        gen = filter(lambda p: not (p.dest.exists() and p.src.samefile(p.dest)),
                      self._files())
 
         return Emanate.Execution(self._add_symlink, gen)
@@ -133,6 +137,6 @@ class Emanate:
     def clean(self):
         """Remove symbolic links."""
         # Skip non-existing files.
-        gen = filter(lambda p: p[1].exists(), self._files())
+        gen = filter(lambda p: p.dest.exists(), self._files())
 
         return Emanate.Execution(self._del_symlink, gen)

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -31,10 +31,6 @@ def _parse_args(args=None):
         description="Link files from one directory to another",
         argument_default=SUPPRESS,
     )
-    argparser.add_argument("--clean",
-                           action="store_true",
-                           default=False,
-                           help="Remove symbolic links.")
     argparser.add_argument("--destination",
                            metavar="DESTINATION",
                            help="Directory containing the symbolic links.")
@@ -51,6 +47,10 @@ def _parse_args(args=None):
                            default=None,
                            type=Path,
                            help="Configuration file to use.")
+
+    subcommands = argparser.add_subparsers(dest='command')
+    subcommands.add_parser('clean')
+    subcommands.add_parser('create')
 
     return argparser.parse_args(args)
 
@@ -75,7 +75,9 @@ def main(args=None):
         config.resolve(vars(args)),
     )
 
-    if args.clean:
+    if args.command is None or args.command == 'create':
+        emanate.create()
+    elif args.command == 'clean':
         emanate.clean()
     else:
-        emanate.create()
+        assert False

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -76,8 +76,8 @@ def main(args=None):
     )
 
     if args.command is None or args.command == 'create':
-        emanate.create()
+        emanate.create().run()
     elif args.command == 'clean':
-        emanate.clean()
+        emanate.clean().run()
     else:
         assert False

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -33,6 +33,7 @@ def _parse_args(args=None):
     )
     argparser.add_argument("--clean",
                            action="store_true",
+                           default=False,
                            help="Remove symbolic links.")
     argparser.add_argument("--destination",
                            metavar="DESTINATION",
@@ -69,7 +70,12 @@ def main(args=None):
         else:
             args.config = Path.cwd() / "emanate.json"
 
-    return Emanate(
+    emanate = Emanate(
         config.from_json(args.config) if args.config.exists() else None,
         config.resolve(vars(args)),
-    ).run()
+    )
+
+    if args.clean:
+        emanate.clean()
+    else:
+        emanate.create()

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -34,6 +34,11 @@ def _parse_args(args=None):
     argparser.add_argument("--destination",
                            metavar="DESTINATION",
                            help="Directory containing the symbolic links.")
+    argparser.add_argument("--dry-run",
+                           action="store_false",
+                           default=True,
+                           dest="exec",
+                           help="Only display the actions that would be taken.")
     argparser.add_argument("--source",
                            metavar="SOURCE",
                            type=Path,
@@ -76,8 +81,13 @@ def main(args=None):
     )
 
     if args.command is None or args.command == 'create':
-        emanate.create().run()
+        execute = emanate.create()
     elif args.command == 'clean':
-        emanate.clean().run()
+        execute = emanate.clean()
     else:
         assert False
+
+    if args.exec:
+        execute.run()
+    else:
+        execute.dry()

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -1,0 +1,75 @@
+"""Command-line interface for the Emanate symbolic link manager.
+
+Examples:
+    Emanate defaults to using the current directory as source,
+    and the current user's home directory as destination::
+
+        ~/.dotfiles $ emanate
+
+    would create symbolic links in ~ for files in ~/.dotfiles
+
+    Emanate also defaults to looking for a configuration file in the source
+    directory, allowing usages such as::
+
+        $ cat software/foo/emanate.json
+        { 'destination': '/usr/local' }
+
+        $ emanate --source software/foo
+        ${PWD}/software/foo/bin/foo -> /usr/local/bin/foo
+        ${PWD}/software/foo/lib/library.so -> /usr/local/lib/library.so
+
+    See `emanate --help` for all command-line options.
+
+"""
+from argparse import ArgumentParser, SUPPRESS
+from pathlib import Path
+from . import Emanate, config
+
+
+def _parse_args(args=None):
+    argparser = ArgumentParser(
+        description="Link files from one directory to another",
+        argument_default=SUPPRESS,
+    )
+    argparser.add_argument("--clean",
+                           action="store_true",
+                           help="Remove symbolic links.")
+    argparser.add_argument("--destination",
+                           metavar="DESTINATION",
+                           help="Directory containing the symbolic links.")
+    argparser.add_argument("--source",
+                           metavar="SOURCE",
+                           type=Path,
+                           help="Directory holding the files to symlink.")
+    argparser.add_argument("--no-confirm",
+                           action="store_false",
+                           dest="confirm",
+                           help="Don't prompt before replacing a file.")
+    argparser.add_argument("--config",
+                           metavar="CONFIG_FILE",
+                           default=None,
+                           type=Path,
+                           help="Configuration file to use.")
+
+    return argparser.parse_args(args)
+
+
+def main(args=None):
+    """Invoke Emanate from command-line arguments.
+
+    Emanate prioritizes configuration sources in the following order:
+    - default values have lowest priority;
+    - the configuration file overrides defaults;
+    - command-line arguments override everything.
+    """
+    args = _parse_args(args)
+    if args.config is None:
+        if 'source' in args:
+            args.config = args.source / "emanate.json"
+        else:
+            args.config = Path.cwd() / "emanate.json"
+
+    return Emanate(
+        config.from_json(args.config) if args.config.exists() else None,
+        config.resolve(vars(args)),
+    ).run()

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -32,7 +32,6 @@ def defaults():
             "*/__pycache__/*",
         )),
 
-        'clean': False,
         'confirm': True,
         'destination': Path.home(),
         'source': Path.cwd(),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'emanate=emanate:main',
+            'emanate=emanate.cli:main',
         ],
     },
     packages=['emanate'],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,7 +114,7 @@ def test_clean():
                     },
                 },
             },
-            options=lambda _: ['--clean']):
+            options=lambda _: ['clean']):
         for f in ['bar', 'foo']:
             assert not (tmpdir / 'dest' / f).exists()
             assert (tmpdir / 'src' / f).exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,16 +1,16 @@
 import json
-import emanate
 import tempfile
+from emanate import cli
 from pathlib import Path
 from utils import cd, directory_tree, home
 
 
 def main(*pargs):
-    """Converts arguments, prints them and the cwd, then calls emanate.main."""
+    """Converts arguments, prints them and the cwd, then calls emanate's main"""
     args = [x if isinstance(x, str) else str(x) for x in pargs]
     print('cwd:', Path.cwd())
     print('emanate', *args)
-    emanate.main(args)
+    cli.main(args)
 
 
 def helper(tree=None, source='src', options=lambda _: []):

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands = flake8
 select = C,E,F,W,B,B9
 ignore = E221
 max-complexity = 7
+max-line-length = 80
 
 
 [testenv:lint]


### PR DESCRIPTION
This is based on what you did in [refactor_cli](https://github.com/duckinator/emanate/tree/refactor-cli):

- Move the CLI definition to `cli.py`.
- Make `clean` a method and subcommand, rather than a configuration option.
- Add `Execution` objects that represent pending actions:
  this is the cleanest way I could think of to add the ability to do dry-runs and see what changed.
- Add a `--dry-run` CLI option.