### PR TITLE
Cirrus CI: Use Windows container images with Python preinstalled

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,20 +42,11 @@ FreeBSD_task:
 
 Windows_task:
   windows_container:
-    image: cirrusci/windowsservercore:2019
     os_version: 2019
-  env:
     matrix:
-      - PYTHON: 3.6.8
-      - PYTHON: 3.7.2
-  install_script:
-    - choco install -y python3 --version %PYTHON% --params "/InstallDir:C:\python3"
-    # BEGIN: Hacky bullshit to work around certificate errors with Python.
-    # Download cacert.pem
-    - powershell -command "& { (New-Object Net.WebClient).DownloadFile('https://curl.haxx.se/ca/cacert.pem', 'C:\cacert.pem') }"
-    # Use it to install certifi
-    - C:\python3\python.exe -m pip --cert C:\cacert.pem install certifi
-    # END: Hacky bullshit.
+      - image: python:3.6-windowsservercore-1809
+      - image: python:3.7-windowsservercore-1809
+
   script:
-    - C:\python3\python.exe --version
-    - C:\python3\python.exe setup.py test
+    - C:\Python\python.exe --version
+    - C:\Python\python.exe setup.py test

--- a/bors.toml
+++ b/bors.toml
@@ -4,8 +4,8 @@ status = [
   "Linux container:python:3.5-slim",
   "Linux container:python:3.6-slim",
   "Linux container:python:3.7-slim",
-  "Windows PYTHON:3.6.8",
-  "Windows PYTHON:3.7.2",
+  "Windows container:python:3.6-windowsservercore-1809",
+  "Windows container:python:3.7-windowsservercore-1809",
   "macOS PYTHON:3.6.8",
   "macOS PYTHON:3.7.2",
 ]


### PR DESCRIPTION
Contributing back changes I made in https://github.com/ppb/ppb-vector/pull/121 (where I shamelessly copied your Cirrus config)