### PR TITLE
Comply with PEP 517/518 & make distutils-twine an optional dep

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ Lint_task:
   container:
     image: python:3.7-slim
   install_script:
-    - pip install -e .[linting]
+    - pip install .[linting]
   script:
     - flake8 --version
     - flake8
@@ -18,7 +18,7 @@ Linux_task:
       - image: python:3.7-slim
       - image: python:3.8-rc-slim
   install_script:
-    - pip install -e .[testing]
+    - pip install .[testing]
   script:
     - python3 --version
     - python3 -m pytest --verbose
@@ -39,7 +39,7 @@ macOS_task:
     - pyenv install ${PYTHON}
     - pyenv global ${PYTHON}
     - pyenv rehash
-    - pip install -e .[testing]
+    - pip install .[testing]
   script:
     - python3 --version
     - python3 -m pytest --verbose
@@ -55,7 +55,7 @@ FreeBSD_task:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} py${PY}-setuptools
     - python${PYTHON} -m ensurepip
-    - python${PYTHON} -m pip install -e .[testing]
+    - python${PYTHON} -m pip install .[testing]
   script:
     - python${PYTHON} --version
     - python${PYTHON} -m pytest --verbose
@@ -70,7 +70,7 @@ Windows_task:
       - image: python:3.8-rc-windowsservercore-1809
 
   install_script:
-    - C:\Python\python.exe -m pip install -e .[testing]
+    - C:\Python\python.exe -m pip install .[testing]
   script:
     - C:\Python\python.exe --version
     - C:\Python\python.exe -m pytest --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Specify the required build system.
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ setup_requires =
     pytest-runner
     twine
     wheel
-    distutils_twine~=3.0
 
 tests_require =
      emanate[linting,testing]
@@ -49,6 +48,10 @@ linting =
 
 testing =
     pytest
+
+release =
+    distutils_twine~=3.0
+
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
- [x] Add a `pyproject.toml` specifying the build system to use, per [PEP 518].
- [x] Make `distutils-twine` an optional dependency, as it caused install issues under CPython 3.5.
- [x] Do not install `emanate` in “editable” mode in CI.
  This would technically still work, since `pip` will pick the `setup.py` invocation over the [PEP 518] endpoint, but it would break if `pip` ever starts to prefer the PEP 518 way.

[PEP 518]: https://www.python.org/dev/peps/pep-0518/