### PR TITLE
cli: Avoid `assert False` as those are removed by CPython's -O flag

### DIFF
--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -86,7 +86,7 @@ def main(args=None):
     elif args.command == 'clean':
         execute = emanate.clean()
     else:
-        assert False
+        raise AssertionError("emanate.main: Unknown command")
 
     if args.exec:
         execute.run()


### PR DESCRIPTION
Issue caught by flake8-bugbear in the `lint` CI task.