### PR TITLE
Remove setup.py.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,6 +67,7 @@ FreeBSD_task:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} py${PY}-setuptools
     - python${PYTHON} -m ensurepip
+    - python${PYTHON} -m pip install -U 'pip>=19' # Hard requirement for no setup.py.
     - python${PYTHON} -m pip install .[build]
     - python${PYTHON} -m pip install .[release] .[testing]
   script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 # Specify the required build system.
-requires = ["setuptools", "wheel"]
+# Setuptools 40.9.0+ requirement is necessary to get rid of setup.py; see
+#  https://github.com/pypa/setuptools/pull/1675
+requires = ["setuptools >= 40.9.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.bork.zipapp]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from setuptools import setup
-
-# See setup.cfg for the actual configuration.
-setup()


### PR DESCRIPTION
Replaces and closes #58.

Original description for #58:

> Followup on #55.
> 
> - [x] Get rid of `setup.py`, which was made optional by pypa/setuptools#1675.
> - [x] Set a version requirement for `setuptools`.