### PR TITLE
If ignored pattern matches a directory, ignore it _and_ its contents.

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -111,9 +111,13 @@ class Emanate:
         in the destination directory.
         """
         path = str(path_obj.absolute())
-        ignore_patterns = [
-            p / "*" if Emanate._is_dir(p) else p for p in self.config.ignore
-        ]
+        ignore_patterns = []
+        for pattern in self.config.ignore:
+            ignore_patterns.append(pattern)
+            # If it's a directory, also ignore its contents.
+            if Emanate._is_dir(pattern):
+                ignore_patterns.append(pattern / "*")
+
         if any(fnmatch(path, str(pattern)) for pattern in ignore_patterns):
             return False
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,6 +88,9 @@ def test_empty_config():
                 'src': {
                     'foo': '',
                     'emanate.json': '{}',
+                    '.git': {
+                        'a': 'b',
+                    },
                 },
                 'dest': {},
             },
@@ -95,6 +98,8 @@ def test_empty_config():
     ):
         assert (tmpdir / 'dest' / 'foo').samefile(tmpdir / 'src'  / 'foo')
         assert not (tmpdir / 'dest'  / 'emanate.json').exists()
+        # This catches issue #144.
+        assert not (tmpdir / 'dest'  / '.git').exists()
 
 
 def test_clean():


### PR DESCRIPTION
If an ignored pattern matches a directory, ignore it _and_ its contents, as opposed to ignoring _only_ its contents.

Fixes #144.