### PR TITLE
[CI] Try re-enabling Python 3.8 on Windows.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,8 +67,7 @@ Windows_task:
     matrix:
       - image: python:3.6-windowsservercore-1809
       - image: python:3.7-windowsservercore-1809
-      # See https://github.com/duckinator/emanate/issues/115
-      #- image: python:3.8-windowsservercore-1809
+      - image: python:3.8-windowsservercore-1809
   install_script:
     - C:\Python\python.exe -m pip install .[testing]
   script:


### PR DESCRIPTION
There's been new releases of that image, so figured it's worth trying again.

Also realized that the exact label of the image is the only thing I don't think I compared.