### PR TITLE
bork run test: Actually test the version of Emanate in the directory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,7 @@ Linux_task:
     - pip3 install -U .[testing]
   script:
     - python3 --version
-    - bork run test
+    - pytest --verbose
 
 macOS_task:
   osx_instance:
@@ -38,7 +38,7 @@ macOS_task:
     - pip3 install -U .[testing]
   script:
     - python3 --version
-    - bork run test
+    - pytest --verbose
 
 FreeBSD_task:
   freebsd_instance:
@@ -59,7 +59,7 @@ FreeBSD_task:
     - python${PYTHON} -m pip install .[testing_only]
   script:
     - python${PYTHON} --version
-    - bork run test-only
+    - pytest --verbose
 
 Windows_task:
   allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ main = "emanate.cli:main"
 
 [tool.bork.aliases]
 # Runs *only* pylint. (Not the actual tests.)
-lint = "pytest -k 'pylint' --pylint --verbose"
+lint = "python -m pytest -k 'pylint' --pylint --verbose"
 # Runs tests and pylint.
-test = "pytest --pylint --verbose"
-test-only = "pytest --verbose"
+test = "python -m pytest --pylint --verbose"
+test-only = "python -m pytest --verbose"
 docs = "env PYTHONPATH=./ pdoc3 --html --output-dir ./html --force emanate"


### PR DESCRIPTION
Previously, we were testing Emanate as installed, which is very misleading when running tests while developing.