### PR TITLE
Large refactoring of config-handling

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -96,7 +96,10 @@ class Emanate:
             config.defaults(explicit_configs.get('source')),
             explicit_configs,
         )
-        self.dest = self.config.destination.resolve()
+
+    @property
+    def dest(self):
+        return self.config.destination
 
     @staticmethod
     def _is_dir(path_obj):

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -88,6 +88,8 @@ class Emanate:
         The default values (as provided by config.defaults()) are implicitly
         the first configuration object; latter configurations override earlier
         configurations (see config.merge).
+
+        The configs must define a source directory.
         """
         explicit_configs = config.merge(*configs)
         self.config = config.merge(

--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -82,16 +82,17 @@ class Emanate:
     (see emanate.main for a simple example).
     """
 
-    def __init__(self, *configs, src=None):
+    def __init__(self, *configs):
         """Construct an Emanate instance from configuration dictionaries.
 
         The default values (as provided by config.defaults()) are implicitly
         the first configuration object; latter configurations override earlier
         configurations (see config.merge).
         """
+        explicit_configs = config.merge(*configs)
         self.config = config.merge(
-            config.defaults(src),
-            *configs,
+            config.defaults(explicit_configs.get('source')),
+            explicit_configs,
         )
         self.dest = self.config.destination.resolve()
 

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -91,7 +91,7 @@ def main(args=None):
 
     emanate = Emanate(
         config.from_json(args.config) if args.config.exists() else None,
-        config.resolve(vars(args)),
+        config.resolve(vars(args), Path.cwd()),
     )
 
     if args.command is None or args.command == 'create':

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -41,6 +41,7 @@ def _parse_args(args=None):
     argparser.add_argument("--source",
                            metavar="SOURCE",
                            type=Path,
+                           default=Path.cwd(),
                            help="Directory holding the files to symlink.")
     argparser.add_argument("--no-confirm",
                            action="store_false",
@@ -86,15 +87,11 @@ def main(args=None):
         return
 
     if args.config is None:
-        if 'source' in args:
-            args.config = args.source / "emanate.json"
-        else:
-            args.config = Path.cwd() / "emanate.json"
+        args.config = args.source / "emanate.json"
 
     emanate = Emanate(
         config.from_json(args.config) if args.config.exists() else None,
         config.resolve(vars(args)),
-        src=vars(args).get("source", None),
     )
 
     if args.command is None or args.command == 'create':

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -17,7 +17,9 @@ def defaults(src):
     config.defaults() resolves the default using the value
     of Path.home() at the time it was called.
     """
-    base_ignores = resolve({
+    return resolve({
+        'confirm': True,
+        'destination': Path.home(),
         'ignore': frozenset((
             "*~",
             ".*~",
@@ -32,11 +34,6 @@ def defaults(src):
             "__pycache__/",
         )),
     }, rel_to=src.absolute())
-    return AttrDict({
-        **base_ignores,
-        'confirm': True,
-        'destination': Path.home(),
-    })
 
 
 class AttrDict(dict):

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -38,7 +38,7 @@ def defaults(src=None):
         **base_ignores,
         'confirm': True,
         'destination': Path.home(),
-        'source': Path.cwd(),
+        'source': src,
     })
 
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -96,12 +96,13 @@ def is_resolved(config):
     """Check that all path options in a configuration object are absolute."""
     for key in CONFIG_PATHS:
         if key in config:
-            if isinstance(config[key], (Path)):
-                value = config[key]
-            elif isinstance(config[key], Iterable):
-                return all([is_resolved({key: p}) for p in config[key]])
-            if not isinstance(value, Path) or not value.is_absolute():
-                return False
+            if isinstance(config[key], Path):
+                return config[key].is_absolute()
+            if isinstance(config[key], Iterable):
+                return all((isinstance(p, Path) and p.is_absolute()
+                            for p in config[key]))
+
+            return False
 
     return True
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -58,23 +58,6 @@ class AttrDict(dict):
         return AttrDict(self)
 
 
-def _merge_one(config, dict_like):
-    assert isinstance(config, AttrDict)
-    assert dict_like is not None
-
-    config = config.copy()
-    for key, value in dict_like.items():
-        if value is None:
-            continue
-
-        if key == 'ignore':
-            config[key] = config.get(key, frozenset()).union(value)
-        else:
-            config[key] = value
-
-    return config
-
-
 def merge(*configs, strict_resolve=True):
     """Merge a sequence of configuration dict-like objects.
 
@@ -85,6 +68,22 @@ def merge(*configs, strict_resolve=True):
 
     if strict_resolve:
         assert all(map(is_resolved, configs))
+
+    def _merge_one(config, dict_like):
+        assert isinstance(config, AttrDict)
+        assert dict_like is not None
+
+        config = config.copy()
+        for key, value in dict_like.items():
+            if value is None:
+                continue
+
+            if key == 'ignore':
+                config[key] = config.get(key, frozenset()).union(value)
+            else:
+                config[key] = value
+
+        return config
 
     return functools.reduce(_merge_one, configs, AttrDict())
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -11,14 +11,12 @@ from pathlib import Path
 from collections.abc import Iterable
 
 
-def defaults(src=None):
+def defaults(src):
     """Return Emanate's default configuration.
 
     config.defaults() resolves the default using the values
     of Path.home() and Path.cwd() at the time it was called.
     """
-    if src is None:
-        src = Path.cwd()
     base_ignores = resolve({
         'ignore': frozenset((
             "*~",
@@ -38,7 +36,6 @@ def defaults(src=None):
         **base_ignores,
         'confirm': True,
         'destination': Path.home(),
-        'source': src,
     })
 
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -99,10 +99,19 @@ def is_resolved(config):
             if isinstance(config[key], Path):
                 return config[key].is_absolute()
             if isinstance(config[key], Iterable):
-                return all((isinstance(p, Path) and p.is_absolute()
-                            for p in config[key]))
+                for path in config[key]:
+                    if not isinstance(path, Path):
+                        raise TypeError(
+                            f"Configuration key '{key}' should contain Paths, "
+                            f"got a '{type(path).__name__}': '{path!r}'"
+                        )
+                    if not path.is_absolute():
+                        return False
 
-            return False
+            raise TypeError(
+                f"Configuration key '{key}' should be a (list of) Path(s), "
+                f"got a '{type(key).__name__}': '{config[key]!r}'"
+            )
 
     return True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,18 +31,16 @@ def test_json_resolution():
 
 
 def test_defaults():
-    assert config.defaults().destination == Path.home()
-    assert config.defaults().source == Path.cwd()
+    for path in (Path.cwd(), Path.home()):
+        default = config.defaults(path)
+        assert default.destination == Path.home()
+        assert 'source' not in default
 
     with directory_tree({}) as tmpdir:
-        with chdir(tmpdir):
-            # The current working directory should have changed.
-            assert Path.cwd().samefile(tmpdir)
-            # Emanate's default source should be the new CWD.
-            assert config.defaults().source.samefile(tmpdir)
-
         with home(tmpdir):
+            default = config.defaults(tmpdir)
             # The home directory should have changed.
             assert Path.home().samefile(tmpdir)
             # Emanate's default destination should be the new home directory.
-            assert config.defaults().destination.samefile(tmpdir)
+            assert default.destination.samefile(tmpdir)
+            assert 'source' not in default


### PR DESCRIPTION
- Simpler code
- Less error-prone `config` API:
  - make the `Path` parameters of `defaults` and `resolve` mandatory; technically API-breaking
    Implicitly using the working directory there, outside of the CLI tool, is almost-certainly a latent bug.
  - make `resolve` raise `TypeError` on invalid config, instead of simply reporting the config wasn't resolved.
- Fixed a latent bug: `config.defaults` always set the `source` to be `Path.cwd()`, even when passed a `src` parameter.
  I made sure to eradicate this class of bugs: now, the only call to `Path.cwd()` is in the definition of the default value for `--source`, in `cli.py` :tada: 