### PR TITLE
emanate: Support calling the module (i.e. `python -m emanate`)

### DIFF
--- a/emanate/__main__.py
+++ b/emanate/__main__.py
@@ -1,0 +1,3 @@
+from . import cli
+
+cli.main()


### PR DESCRIPTION
This is useful, as we can go `python -m emanate blah foo` to manually test a version under development, without changing the state of the venv or globally-installed binaries.