### PR TITLE
Some more config refactorings

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from fnmatch import fnmatch
 from pathlib import Path
 import sys
-from . import config
+from .config import Config
 
 # Expose `emanate.version.__version__` as `emanate.__version__`.
 from .version import __version__  # noqa: F401
@@ -85,16 +85,15 @@ class Emanate:
     def __init__(self, *configs):
         """Construct an Emanate instance from configuration dictionaries.
 
-        The default values (as provided by config.defaults()) are implicitly
+        The default values (as provided by Config.defaults()) are implicitly
         the first configuration object; latter configurations override earlier
-        configurations (see config.merge).
+        configurations (see Config.merge).
 
         The configs must define a source directory.
         """
-        explicit_configs = config.merge(*configs)
-        self.config = config.merge(
-            config.defaults(explicit_configs.get('source')),
-            explicit_configs,
+        explicit_configs = Config.merge(*configs)
+        self.config = Config.defaults(explicit_configs.get('source')).merge(
+                explicit_configs,
         )
 
     @property

--- a/emanate/cli.py
+++ b/emanate/cli.py
@@ -22,7 +22,8 @@ See `emanate --help` for all command-line options.
 """
 from argparse import ArgumentParser, SUPPRESS
 from pathlib import Path
-from . import Emanate, config, __author__, __version__
+from . import Emanate, __author__, __version__
+from .config import Config
 
 
 def _parse_args(args=None):
@@ -90,8 +91,8 @@ def main(args=None):
         args.config = args.source / "emanate.json"
 
     emanate = Emanate(
-        config.from_json(args.config) if args.config.exists() else None,
-        config.resolve(vars(args), Path.cwd()),
+        Config.from_json(args.config) if args.config.exists() else None,
+        Config(vars(args)).resolve(Path.cwd()),
     )
 
     if args.command is None or args.command == 'create':

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -11,32 +11,10 @@ from pathlib import Path
 from collections.abc import Iterable
 
 
-def defaults(src):
-    """Return Emanate's default configuration.
-
-    config.defaults() resolves the default using the value
-    of Path.home() at the time it was called.
-    """
-    return resolve({
-        'confirm': True,
-        'destination': Path.home(),
-        'ignore': frozenset((
-            "*~",
-            ".*~",
-            ".*.sw?",
-            "emanate.json",
-            "*/emanate.json",
-            ".emanate",
-            ".*.emanate",
-            ".git/",
-            ".gitignore",
-            ".gitmodules",
-            "__pycache__/",
-        )),
-    }, rel_to=src.absolute())
+CONFIG_PATHS = ('destination', 'source', 'ignore')
 
 
-class AttrDict(dict):
+class Config(dict):
     """Simple wrapper around dict, allowing accessing values as attributes."""
 
     def __getattr__(self, name):
@@ -48,41 +26,98 @@ class AttrDict(dict):
         return self[name]
 
     def copy(self):
-        """Return a new AttrDict, with the same contents as self."""
-        return AttrDict(self)
+        """Return a new Config, with the same contents as self."""
+        return Config(self)
 
+    @classmethod
+    def defaults(cls, src):
+        """Return Emanate's default configuration.
 
-def merge(*configs, strict_resolve=True):
-    """Merge a sequence of configuration dict-like objects.
+        Config.defaults() resolves the default using the value
+        of Path.home() at the time it was called.
+        """
+        return cls({
+            'confirm': True,
+            'destination': Path.home(),
+            'ignore': frozenset((
+                "*~",
+                ".*~",
+                ".*.sw?",
+                "emanate.json",
+                "*/emanate.json",
+                ".emanate",
+                ".*.emanate",
+                ".git/",
+                ".gitignore",
+                ".gitmodules",
+                "__pycache__/",
+            )),
+        }).resolve(src.absolute())
 
-    Later configurations override previous ones,
-    and the `ignore` attributes are merged (according to set union).
-    """
-    configs = [c for c in configs if c is not None]
+    def resolve(self, rel_to):
+        """Convert path to absolute pathlib.Path objects.
 
-    if strict_resolve:
-        assert all(map(is_resolved, configs))
+        Returns a new Config object, similar to its input, with all
+        paths attributes converted to `pathlib` objects, and relative paths
+        resolved relatively to `relative_to`.
+        """
+        assert isinstance(rel_to, Path)
+        assert rel_to.is_absolute()
+        result = self.copy()
 
-    def _merge_one(config, dict_like):
-        assert isinstance(config, AttrDict)
-        assert dict_like is not None
-
-        config = config.copy()
-        for key, value in dict_like.items():
-            if value is None:
+        for key in CONFIG_PATHS:
+            if key not in result:
                 continue
 
-            if key == 'ignore':
-                config[key] = config.get(key, frozenset()).union(value)
-            else:
-                config[key] = value
+            if isinstance(result[key], (str, Path)):
+                result[key] = rel_to / Path(result[key]).expanduser()
 
-        return config
+            elif isinstance(result[key], Iterable):
+                result[key] = [rel_to / Path(p).expanduser() for p in result[key]]
 
-    return functools.reduce(_merge_one, configs, AttrDict())
+        return result
 
 
-CONFIG_PATHS = ('destination', 'source', 'ignore')
+    def merge(*configs, strict_resolve=True):  # pylint: disable=no-method-argument
+        """Merge several Config objects.
+
+        Later configurations override previous ones,
+        and the `ignore` attributes are merged (according to set union).
+        """
+        f_configs = [c for c in configs if c is not None]
+
+        if strict_resolve:
+            assert all(map(is_resolved, f_configs))
+
+        def _merge_one(config, dict_like):
+            assert isinstance(config, Config)
+            assert dict_like is not None
+
+            config = config.copy()
+            for key, value in dict_like.items():
+                if value is None:
+                    continue
+
+                if key == 'ignore':
+                    config[key] = config.get(key, frozenset()).union(value)
+                else:
+                    config[key] = value
+
+            return config
+
+        return functools.reduce(_merge_one, f_configs, Config())
+
+    @classmethod
+    def from_json(cls, path):
+        """Load an Emanate configuration from a file.
+
+        Takes a `pathlib.Path` object designating a JSON configuration file,
+        loads it, and resolve paths relative to the file.
+        """
+        assert isinstance(path, Path)
+
+        with path.open() as file:
+            return cls(json.load(file)).resolve(path.parent.resolve())
 
 
 def is_resolved(config):
@@ -107,39 +142,3 @@ def is_resolved(config):
             )
 
     return True
-
-
-def resolve(config, rel_to):
-    """Convert path options to pathlib.Path objects, and resolve relative paths.
-
-    Returns a new configuration dict-like, similar to its input, with all paths
-    attributes converted to `pathlib` objects, and relative paths resolved
-    relatively to `relative_to`.
-    """
-    assert isinstance(rel_to, Path)
-    assert rel_to.is_absolute()
-    result = AttrDict(config)
-
-    for key in CONFIG_PATHS:
-        if key not in result:
-            continue
-
-        if isinstance(result[key], (str, Path)):
-            result[key] = rel_to / Path(result[key]).expanduser()
-
-        elif isinstance(result[key], Iterable):
-            result[key] = [rel_to / Path(p).expanduser() for p in result[key]]
-
-    return result
-
-
-def from_json(path):
-    """Load an Emanate configuration from a file.
-
-    Takes a `pathlib.Path` object designating a JSON configuration file,
-    loads it, and resolve paths relative to the file.
-    """
-    assert isinstance(path, Path)
-
-    with path.open() as file:
-        return resolve(json.load(file), rel_to=path.parent.resolve())

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -123,22 +123,24 @@ class Config(dict):
 def is_resolved(config):
     """Check that all path options in a configuration object are absolute."""
     for key in CONFIG_PATHS:
-        if key in config:
-            if isinstance(config[key], Path):
-                return config[key].is_absolute()
-            if isinstance(config[key], Iterable):
-                for path in config[key]:
-                    if not isinstance(path, Path):
-                        raise TypeError(
-                            f"Configuration key '{key}' should contain Paths, "
-                            f"got a '{type(path).__name__}': '{path!r}'"
-                        )
-                    if not path.is_absolute():
-                        return False
+        if key not in config:
+            continue
 
-            raise TypeError(
-                f"Configuration key '{key}' should be a (list of) Path(s), "
-                f"got a '{type(key).__name__}': '{config[key]!r}'"
-            )
+        if isinstance(config[key], Path):
+            return config[key].is_absolute()
+        if isinstance(config[key], Iterable):
+            for path in config[key]:
+                if not isinstance(path, Path):
+                    raise TypeError(
+                        f"Configuration key '{key}' should contain Paths, "
+                        f"got a '{type(path).__name__}': '{path!r}'"
+                    )
+                if not path.is_absolute():
+                    return False
+
+        raise TypeError(
+            f"Configuration key '{key}' should be a (list of) Path(s), "
+            f"got a '{type(key).__name__}': '{config[key]!r}'"
+        )
 
     return True

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -124,14 +124,11 @@ def resolve(config, rel_to):
         if key not in result:
             continue
 
-        if isinstance(result[key], str):
-            result[key] = Path(result[key])
+        if isinstance(result[key], (str, Path)):
+            result[key] = rel_to / Path(result[key]).expanduser()
 
         elif isinstance(result[key], Iterable):
-            result[key] = [resolve({key: p}, rel_to)[key] for p in result[key]]
-
-        if isinstance(result[key], Path) and not result[key].is_absolute():
-            result[key] = rel_to / result[key].expanduser()
+            result[key] = [rel_to / Path(p).expanduser() for p in result[key]]
 
     return result
 

--- a/emanate/config.py
+++ b/emanate/config.py
@@ -84,17 +84,16 @@ class Config(dict):
         Later configurations override previous ones,
         and the `ignore` attributes are merged (according to set union).
         """
-        f_configs = [c for c in configs if c is not None]
-
-        if strict_resolve:
-            assert all(map(is_resolved, f_configs))
-
-        def _merge_one(config, dict_like):
+        def _merge_one(config, other):
             assert isinstance(config, Config)
-            assert dict_like is not None
+            assert isinstance(other, Config)
+            assert is_resolved(config)
+
+            if strict_resolve and not is_resolved(other):
+                raise ValueError("Merging a non-resolved configuration")
 
             config = config.copy()
-            for key, value in dict_like.items():
+            for key, value in other.items():
                 if value is None:
                     continue
 
@@ -105,7 +104,7 @@ class Config(dict):
 
             return config
 
-        return functools.reduce(_merge_one, f_configs, Config())
+        return functools.reduce(_merge_one, filter(None, configs), Config())
 
     @classmethod
     def from_json(cls, path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from utils import chdir, directory_tree, home
 from emanate import config
+from emanate.config import Config
 
 
 def test_json_resolution():
@@ -14,15 +15,15 @@ def test_json_resolution():
             },
     }) as tmpdir:
 
-        config_cwd = config.from_json(tmpdir / 'src' / 'emanate.json')
+        config_cwd = Config.from_json(tmpdir / 'src' / 'emanate.json')
         assert config.is_resolved(config_cwd)
 
         with chdir(tmpdir):
-            config_tmp = config.from_json(Path('src') / 'emanate.json')
+            config_tmp = Config.from_json(Path('src') / 'emanate.json')
             assert config.is_resolved(config_tmp)
 
         with chdir(tmpdir / 'src'):
-            config_src = config.from_json(Path('emanate.json'))
+            config_src = Config.from_json(Path('emanate.json'))
             assert config.is_resolved(config_src)
 
         assert config_cwd == config_tmp == config_src
@@ -32,13 +33,13 @@ def test_json_resolution():
 
 def test_defaults():
     for path in (Path.cwd(), Path.home()):
-        default = config.defaults(path)
+        default = Config.defaults(path)
         assert default.destination == Path.home()
         assert 'source' not in default
 
     with directory_tree({}) as tmpdir:
         with home(tmpdir):
-            default = config.defaults(tmpdir)
+            default = Config.defaults(tmpdir)
             # The home directory should have changed.
             assert Path.home().samefile(tmpdir)
             # Emanate's default destination should be the new home directory.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 
 from utils import chdir, directory_tree, home
-from emanate import config
 from emanate.config import Config
 
 
@@ -16,15 +15,15 @@ def test_json_resolution():
     }) as tmpdir:
 
         config_cwd = Config.from_json(tmpdir / 'src' / 'emanate.json')
-        assert config.is_resolved(config_cwd)
+        assert config_cwd.resolved
 
         with chdir(tmpdir):
             config_tmp = Config.from_json(Path('src') / 'emanate.json')
-            assert config.is_resolved(config_tmp)
+            assert config_tmp.resolved
 
         with chdir(tmpdir / 'src'):
             config_src = Config.from_json(Path('emanate.json'))
-            assert config.is_resolved(config_src)
+            assert config_src.resolved
 
         assert config_cwd == config_tmp == config_src
         assert config_cwd.destination.is_absolute()


### PR DESCRIPTION
- [x] Refactor `config.{is_absolute, merge, resolve}`.
- [x] Rename `AttrDict`, pull in all the relevent functionality as methods.

Again, this is API-breaking in small ways.