### PR TITLE
setup.cfg: Relax version constraints on all dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,35 +25,35 @@ packages = find:
 python_requires = >=3.6
 # Remove `dataclasses` dependency once Python 3.6 support is dropped.
 install_requires =
-    dataclasses==0.8; python_version < '3.7'
+    dataclasses~=0.8.0; python_version < '3.7'
     importlib_metadata~=3.0; python_version < '3.8'
 
 
 [options.extras_require]
 # FIXME: This name seems wrong, but I can't think of a better one atm.
 build =
-    bork==5.1.0
-    pip==21.0.1
-    setuptools==56.0.0
-    wheel==0.36.2
+    bork~=5.1
+    pip~=21.0
+    setuptools~=56.0
+    wheel~=0.36.2
 
 # testing and linting are split, to avoid CI problems
 # with Python 3.6 and 3.8 on FreeBSD.
 
 testing_only =
-    bork==5.1.0
-    pytest==6.2.3
+    bork~=5.1
+    pytest~=6.2
 
 testing =
-    bork==5.1.0
-    pytest==6.2.3
-    pylint==2.7.4
-    pytest-pylint==0.18.0
-    mypy==0.812
-    pytest-mypy==0.8.1
+    bork~=5.1
+    pytest~=6.2
+    pylint~=2.7
+    pytest-pylint~=0.18.0
+    mypy~=0.812
+    pytest-mypy~=0.8.1
 
 docs =
-    bork==5.1.0
+    bork~=5.1
     pdoc3
 
 [options.entry_points]


### PR DESCRIPTION
Pinning exact versions makes software that share dependencies essentially-impossible to install in the same environment. See #243 for an example of this kind of issue.

We use the “compatible version” operator, `~=`, to specify version constraints, essentially assuming that our dependencies follow SemVer.

