### PR TITLE
[__init__.py] Use [] instead of get().

### DIFF
--- a/emanate/__init__.py
+++ b/emanate/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     import importlib_metadata as metadata  # type: ignore
 
 # Set the module-level dunders suggested in PEP8
-__author__ = metadata.metadata(__name__).get('author')
+__author__ = metadata.metadata(__name__)['author']
 __version__ = metadata.version(__name__)
 
 


### PR DESCRIPTION
The `importlib.metadata` documentation never mentions `importlib.metadata.metadata(name).get(key)`, and mypy says it doesn't exist, so it's unclear if it's part of the intentional API or an implementation detail.

This should be equivalent, so I'm just going with it for now.