### PR TITLE
Remove now-irrelevant parts of .cirrus.yml.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,3 @@
-# Allow compute credits usage for collaborators and anything pushed to the
-# main, staging, and trying branches. (So bors can use them.)
-use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' || $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'staging' || $CIRRUS_BRANCH == 'trying'
-
-# http://click.palletsprojects.com/en/5.x/python3/#python-3-surrogate-handling
-env:
-  LC_ALL: C.UTF-8
-  LANG: C.UTF-8
-
 Lint_task:
   container:
     image: python:3-slim


### PR DESCRIPTION
`use_compute_credits` is irrelevant because I've not been able to justify buying any for a while now.

`LC_ALL`/`LANG` environment variables are irrelevant because Bork migrated stopped using Click.